### PR TITLE
Fix: Redirect to Root on Sign-Out When Accessing Authenticated Page

### DIFF
--- a/frontend/app/_components/layouts/AppLayout.tsx
+++ b/frontend/app/_components/layouts/AppLayout.tsx
@@ -16,6 +16,7 @@ import { FloatingCircles } from './floating_circle/FloatingCircles';
 import TopPageProvider from '@/app/_features/top/TopPageContext';
 import { useTopPage } from '@/app/_features/top/TopPageContext';
 import { motion } from 'framer-motion';
+import { useRouter } from 'next/navigation';
 
 export const notojp = Noto_Sans_JP({
   weight: ["400", "700"],
@@ -55,14 +56,26 @@ function LayoutContent( {children}: AppLayoutProps ){
   const { data: session, status } = useSession();
   const [ hasVisited, setHasVisited] = useState<string>('');
   const { isViewed, setIsViewed } = useTopPage();
+  const router = useRouter();
   const isRoot = usePathname();
-  console.log(status)
-  console.log(isRoot)
-  console.log(isViewed)
+  const unAuthFlag = sessionStorage.getItem('unAuthFlag');
+
+  {/* デバッグ用 */}
+  console.log("unAuthFlag: " + unAuthFlag)
+  console.log("status: " + status)
+  console.log("isRoot: " + isRoot)
+  console.log("isViewed: " + isViewed)
 
   useEffect(() => {
     if(isRoot != '/'){setIsViewed(true)}
   }, [isRoot])
+
+  useEffect(() => {
+    if (unAuthFlag === 'true') {
+      router.push('/');
+      sessionStorage.removeItem('unAuthFlag');
+    }
+  }, [unAuthFlag]);
 
   useEffect(() => {
     const storedHasVisited = sessionStorage.getItem('hasVisited');
@@ -78,6 +91,9 @@ function LayoutContent( {children}: AppLayoutProps ){
           <Image src="/images/background.png" alt="background" layout="fill"
                  className="absolute top-50% left-50% min-w-full min-h-full object-cover z-0"/>
           { isRoot && <FloatingCircles />}
+          {/* ローディング画面 */}
+          { status == 'loading' && <Loading />}
+          {/* メインコンテンツ */}
           { status != 'loading' && (
             <div className='flex flex-col h-full'>
               { isViewed && (

--- a/frontend/app/_components/layouts/header/private.tsx
+++ b/frontend/app/_components/layouts/header/private.tsx
@@ -3,41 +3,40 @@
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { signOut } from 'next-auth/react';
-import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import type { MouseEvent } from 'react';
 import axios from 'axios';
 
-const handleLogout = async (event: MouseEvent<HTMLElement>) => {
-  event.preventDefault();
-  try {
-    await signOut();
-    const destroySession = await axios({
-      method: 'post',
-      url: `${process.env.NEXT_PUBLIC_API_URL}/auth/google/logout`,
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      withCredentials: true,
-    });
-
-    if (destroySession.status === 200) {
-      console.log('Session destroyed successfully');
-    } else {
-      console.error('Error destroying session', destroySession);
-    }
-  } catch (error) {
-    console.error('Catch error', error);
-  }
-};
-
 export default function PublicHeader() {
   const [ avatar, setAvatar ]= useState<string>('');
   const { data: session } = useSession();
-  const isRoot = usePathname();
 
   useEffect(() => {
     const user_image = session?.user.image ? session.user.image : '';
     setAvatar(user_image);
   },[])
+
+  const handleLogout = async (event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    sessionStorage.setItem('unAuthFlag', 'true');
+    try {
+      await signOut();
+      const destroySession = await axios({
+        method: 'post',
+        url: `${process.env.NEXT_PUBLIC_API_URL}/auth/google/logout`,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        withCredentials: true,
+      });
+
+      if (destroySession.status === 200) {
+        console.log('Session destroyed successfully');
+      } else {
+        console.error('Error destroying session', destroySession);
+      }
+    } catch (error) {
+      console.error('Catch error', error);
+    }
+  };
 
   return (
     <>

--- a/frontend/app/_features/AuthGuard.tsx
+++ b/frontend/app/_features/AuthGuard.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
-import Loading from '../_components/layouts/loading/layout';
+import { useTopPage } from '@/app/_features/top/TopPageContext';
 
 const unAuthenticatedPaths = ['/privacy-policy', '/terms-of-service'];
 
@@ -12,11 +12,18 @@ const AuthGuard = ({ children }: { children: React.ReactNode }): any => {
   const router = useRouter();
   const isRoute = usePathname();
 
+  {/* 非認証状態で認可されていないページにアクセスした場合 */}
   useEffect(() => {
-    if ((status === 'unauthenticated' || status === null) && (!unAuthenticatedPaths.includes(isRoute) || isRoute == '/')) {router.replace('/');}
+    if ((status === 'unauthenticated' || status === null) &&
+        (!unAuthenticatedPaths.includes(isRoute) || isRoute == '/'))
+        { router.replace('/'); }
   }, [router, status]);
-  if (status === 'loading') return <Loading />;
-  if ((status === 'unauthenticated' || status === null) && (unAuthenticatedPaths.includes(isRoute))) { return children };
+
+  {/* 非認証状態で認可されているページにアクセスした場合 */}
+  if ((status === 'unauthenticated' || status === null) &&
+      (unAuthenticatedPaths.includes(isRoute)))
+      { return children; };
+  {/* 認証状態でページにアクセスした場合 */}
   if (status === 'authenticated') return children;
 };
 


### PR DESCRIPTION
[…ges in Authenticated State](https://github.com/zio-tt/mirai_select/issues/38#issue-2019902450)

サインアウトした時にプライバシーポリシーや利用規約のページからサインアウトした場合
ルートに遷移する様に修正